### PR TITLE
feat: add support for nonce

### DIFF
--- a/.changeset/heavy-eels-trade.md
+++ b/.changeset/heavy-eels-trade.md
@@ -2,4 +2,4 @@
 "@marko/express": minor
 ---
 
-Add support for CSP Nonce in redirect scropt
+Add support for CSP Nonce in redirect script

--- a/.changeset/heavy-eels-trade.md
+++ b/.changeset/heavy-eels-trade.md
@@ -1,0 +1,5 @@
+---
+"@marko/express": minor
+---
+
+Add support for CSP Nonce in redirect scropt

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If `$global` includes a `cspNonce` it will be included in the redirect script.
 ```js
 app.get("/", (req, res) => {
   // <script nonce="xyz">
-  res.marko(Template, { $global: { cspNonce: 'xyz' }});
+  res.marko(Template, { $global: { cspNonce: "xyz" } });
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,13 @@ If `$global` includes a `cspNonce` it will be included in the redirect script.
 
 ```js
 app.get("/", (req, res) => {
-  // <script nonce="xyz">
   res.marko(Template, { $global: { cspNonce: "xyz" } });
+
+  // If a redirect occurs mid stream we'll see
+  // something like the following in the output:
+  //
+  // <meta http-equiv=refresh content="0;url=...">
+  // <script nonce="xyz">location.href="..."></script>
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Then later in a template access via:
 
 Allows `res.redirect` to redirect HTML responses that have already begun sending content. This is done by flushing a `<meta>` tag redirect with a `<script>` fallback before prematurely ending the response.
 
+If `$global` includes a `cspNonce` it will be included in the redirect script.
+
+```js
+app.get("/", (req, res) => {
+  // <script nonce="xyz">
+  res.marko(Template, { $global: { cspNonce: 'xyz' }});
+});
+```
+
 # Code of Conduct
 
 This project adheres to the [eBay Code of Conduct](./.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -149,6 +149,31 @@ test("Midstream Redirect, HTML", async () => {
   expect(html).toMatchInlineSnapshot(`"You need to login!"`);
 });
 
+test("Midstream Redirect, HTML, nonce", async () => {
+  let spy;
+  await fetchHtml(
+    express()
+      .use(markoMiddleware())
+      .use((req, res) => {
+        if (req.url === "/login.html") {
+          return res.end("You need to login!");
+        }
+
+        const promise = new Promise((resolve) => {
+          setTimeout(() => {
+            spy = jest.spyOn(res, 'write');
+            res.redirect("/login.html");
+            resolve("hello");
+          }, 50);
+        });
+
+        res.marko(AsyncTemplate, { $global: {cspNonce: 'xyz' }, promise });
+      })
+  );
+
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining('<script nonce="xyz">'));
+});
+
 test("Midstream Redirect, HTML, compression", async () => {
   const { res, html } = await fetchHtml(
     express()

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -161,17 +161,19 @@ test("Midstream Redirect, HTML, nonce", async () => {
 
         const promise = new Promise((resolve) => {
           setTimeout(() => {
-            spy = jest.spyOn(res, 'write');
+            spy = jest.spyOn(res, "write");
             res.redirect("/login.html");
             resolve("hello");
           }, 50);
         });
 
-        res.marko(AsyncTemplate, { $global: {cspNonce: 'xyz' }, promise });
+        res.marko(AsyncTemplate, { $global: { cspNonce: "xyz" }, promise });
       })
   );
 
-  expect(spy).toHaveBeenCalledWith(expect.stringContaining('<script nonce="xyz">'));
+  expect(spy).toHaveBeenCalledWith(
+    expect.stringContaining('<script nonce="xyz">')
+  );
 });
 
 test("Midstream Redirect, HTML, compression", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import type { EventEmitter } from "events";
 import type { Request, Response, NextFunction } from "express";
-import { createRedirectWithMidstreamSupportFn, redirectWithMidstreamSupport } from "./redirect";
+import {
+  createRedirectWithMidstreamSupportFn,
+  redirectWithMidstreamSupport,
+} from "./redirect";
 
 // newer versions of `@types/express`
 declare module "express-serve-static-core" {

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,7 +1,9 @@
 import type { Response } from "express";
 import { ServerResponse } from "http";
 
-export function createRedirectWithMidstreamSupportFn({ cspNonce }: { cspNonce?: string; } = {}) {
+export function createRedirectWithMidstreamSupportFn({
+  cspNonce,
+}: { cspNonce?: string } = {}) {
   function redirectWithMidstreamSupport(
     this: Response,
     status: number,
@@ -23,7 +25,7 @@ export function createRedirectWithMidstreamSupportFn({ cspNonce }: { cspNonce?: 
   ) {
     const status = typeof p1 === "number" ? p1 : 302;
     const redirectUrl = typeof p1 === "string" ? p1 : (p2 as string);
-    const nonce = cspNonce ? ` nonce="${cspNonce}"` : '';
+    const nonce = cspNonce ? ` nonce="${cspNonce}"` : "";
 
     if (
       this.headersSent &&
@@ -31,7 +33,6 @@ export function createRedirectWithMidstreamSupportFn({ cspNonce }: { cspNonce?: 
         "text/html"
       )
     ) {
-
       // already begun response, so we can't redirect with a status code
       // but it is text/html, so we can redirect using <meta> refresh or location.href
       // and destroy the stream once the response is flushed
@@ -60,7 +61,8 @@ export function createRedirectWithMidstreamSupportFn({ cspNonce }: { cspNonce?: 
   return redirectWithMidstreamSupport;
 }
 
-export const redirectWithMidstreamSupport = createRedirectWithMidstreamSupportFn();
+export const redirectWithMidstreamSupport =
+  createRedirectWithMidstreamSupportFn();
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noopThis(this: any) {

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,58 +1,66 @@
 import type { Response } from "express";
 import { ServerResponse } from "http";
 
-export function redirectWithMidstreamSupport(
-  this: Response,
-  status: number,
-  redirectUrl: string
-): void;
-export function redirectWithMidstreamSupport(
-  this: Response,
-  redirectUrl: string,
-  status: number
-): void;
-export function redirectWithMidstreamSupport(
-  this: Response,
-  redirectUrl: string
-): void;
-export function redirectWithMidstreamSupport(
-  this: Response,
-  p1: string | number,
-  p2?: string | number
-) {
-  const status = typeof p1 === "number" ? p1 : 302;
-  const redirectUrl = typeof p1 === "string" ? p1 : (p2 as string);
-
-  if (
-    this.headersSent &&
-    (this.getHeader("Content-Type") as string | undefined)?.startsWith(
-      "text/html"
-    )
+export function createRedirectWithMidstreamSupportFn({ cspNonce }: { cspNonce?: string; } = {}) {
+  function redirectWithMidstreamSupport(
+    this: Response,
+    status: number,
+    redirectUrl: string
+  ): void;
+  function redirectWithMidstreamSupport(
+    this: Response,
+    redirectUrl: string,
+    status: number
+  ): void;
+  function redirectWithMidstreamSupport(
+    this: Response,
+    redirectUrl: string
+  ): void;
+  function redirectWithMidstreamSupport(
+    this: Response,
+    p1: string | number,
+    p2?: string | number
   ) {
-    // already begun response, so we can't redirect with a status code
-    // but it is text/html, so we can redirect using <meta> refresh or location.href
-    // and destroy the stream once the response is flushed
-    (this as any)[onWriteFlush] = this.destroy;
-    this.write(`
-      <meta http-equiv=refresh content=${JSON.stringify(
-        `0;url=${redirectUrl}`
-      )}>
-      <script>location.href=${JSON.stringify(redirectUrl)}</script>
-    `);
+    const status = typeof p1 === "number" ? p1 : 302;
+    const redirectUrl = typeof p1 === "string" ? p1 : (p2 as string);
+    const nonce = cspNonce ? ` nonce="${cspNonce}"` : '';
 
-    // special case: compression
-    // ensure the redirect is flushed when compression middleware is used
-    if (this.flush) this.flush();
+    if (
+      this.headersSent &&
+      (this.getHeader("Content-Type") as string | undefined)?.startsWith(
+        "text/html"
+      )
+    ) {
 
-    // prevent any further output
-    this.write = noopTrue;
-    this.flush = this.end = noopThis;
-  } else {
-    // use the default redirect behavior
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    Object.getPrototypeOf(this).redirect.call(this, status, redirectUrl);
+      // already begun response, so we can't redirect with a status code
+      // but it is text/html, so we can redirect using <meta> refresh or location.href
+      // and destroy the stream once the response is flushed
+      (this as any)[onWriteFlush] = this.destroy;
+      this.write(`
+        <meta http-equiv=refresh content=${JSON.stringify(
+          `0;url=${redirectUrl}`
+        )}>
+        <script${nonce}>location.href=${JSON.stringify(redirectUrl)}</script>
+      `);
+
+      // special case: compression
+      // ensure the redirect is flushed when compression middleware is used
+      if (this.flush) this.flush();
+
+      // prevent any further output
+      this.write = noopTrue;
+      this.flush = this.end = noopThis;
+    } else {
+      // use the default redirect behavior
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      Object.getPrototypeOf(this).redirect.call(this, status, redirectUrl);
+    }
   }
+
+  return redirectWithMidstreamSupport;
 }
+
+export const redirectWithMidstreamSupport = createRedirectWithMidstreamSupportFn();
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noopThis(this: any) {

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,68 +1,69 @@
 import type { Response } from "express";
 import { ServerResponse } from "http";
 
-export function createRedirectWithMidstreamSupportFn({
-  cspNonce,
-}: { cspNonce?: string } = {}) {
-  function redirectWithMidstreamSupport(
-    this: Response,
-    status: number,
-    redirectUrl: string
-  ): void;
-  function redirectWithMidstreamSupport(
-    this: Response,
-    redirectUrl: string,
-    status: number
-  ): void;
-  function redirectWithMidstreamSupport(
-    this: Response,
-    redirectUrl: string
-  ): void;
-  function redirectWithMidstreamSupport(
-    this: Response,
-    p1: string | number,
-    p2?: string | number
-  ) {
-    const status = typeof p1 === "number" ? p1 : 302;
-    const redirectUrl = typeof p1 === "string" ? p1 : (p2 as string);
-    const nonce = cspNonce ? ` nonce="${cspNonce}"` : "";
+export const kCSPNonce = Symbol("cspNonce");
+const kOnWriteFlush = Symbol("on-flush");
 
-    if (
-      this.headersSent &&
-      (this.getHeader("Content-Type") as string | undefined)?.startsWith(
-        "text/html"
-      )
-    ) {
-      // already begun response, so we can't redirect with a status code
-      // but it is text/html, so we can redirect using <meta> refresh or location.href
-      // and destroy the stream once the response is flushed
-      (this as any)[onWriteFlush] = this.destroy;
-      this.write(`
+export interface ResponseWithInternals extends Response {
+  [kCSPNonce]?: string;
+  [kOnWriteFlush]?: (this: ResponseWithInternals) => void;
+}
+
+export function redirectWithMidstreamSupport(
+  this: ResponseWithInternals,
+  status: number,
+  redirectUrl: string
+): void;
+export function redirectWithMidstreamSupport(
+  this: ResponseWithInternals,
+  redirectUrl: string,
+  status: number
+): void;
+export function redirectWithMidstreamSupport(
+  this: ResponseWithInternals,
+  redirectUrl: string
+): void;
+export function redirectWithMidstreamSupport(
+  this: ResponseWithInternals,
+  p1: string | number,
+  p2?: string | number
+) {
+  const status = typeof p1 === "number" ? p1 : 302;
+  const redirectUrl = typeof p1 === "string" ? p1 : (p2 as string);
+  const nonce = this[kCSPNonce]
+    ? ` nonce=${JSON.stringify(this[kCSPNonce])}`
+    : "";
+
+  if (
+    this.headersSent &&
+    (this.getHeader("Content-Type") as string | undefined)?.startsWith(
+      "text/html"
+    )
+  ) {
+    // already begun response, so we can't redirect with a status code
+    // but it is text/html, so we can redirect using <meta> refresh or location.href
+    // and destroy the stream once the response is flushed
+    this[kOnWriteFlush] = this.destroy;
+    this.write(`
         <meta http-equiv=refresh content=${JSON.stringify(
           `0;url=${redirectUrl}`
         )}>
         <script${nonce}>location.href=${JSON.stringify(redirectUrl)}</script>
       `);
 
-      // special case: compression
-      // ensure the redirect is flushed when compression middleware is used
-      if (this.flush) this.flush();
+    // special case: compression
+    // ensure the redirect is flushed when compression middleware is used
+    if (this.flush) this.flush();
 
-      // prevent any further output
-      this.write = noopTrue;
-      this.flush = this.end = noopThis;
-    } else {
-      // use the default redirect behavior
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      Object.getPrototypeOf(this).redirect.call(this, status, redirectUrl);
-    }
+    // prevent any further output
+    this.write = noopTrue;
+    this.flush = this.end = noopThis;
+  } else {
+    // use the default redirect behavior
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    Object.getPrototypeOf(this).redirect.call(this, status, redirectUrl);
   }
-
-  return redirectWithMidstreamSupport;
 }
-
-export const redirectWithMidstreamSupport =
-  createRedirectWithMidstreamSupportFn();
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noopThis(this: any) {
@@ -77,14 +78,13 @@ function noopTrue() {
 // but monkeypatching is so common in the express ecosystem that we can't rely on the callback
 // specifically, compression middleware omits the callback
 const _write = ServerResponse.prototype.write;
-const onWriteFlush = Symbol("on-flush");
 ServerResponse.prototype.write = function (
-  this: any,
+  this: ResponseWithInternals,
   data: any,
   encoding: any,
   callback: any
 ) {
-  if (!this[onWriteFlush]) return _write.call(this, data, encoding, callback);
+  if (!this[kOnWriteFlush]) return _write.call(this, data, encoding, callback);
 
   if (typeof encoding === "function") {
     callback = encoding;
@@ -92,7 +92,7 @@ ServerResponse.prototype.write = function (
   }
 
   return _write.call(this, data, encoding, () => {
-    this[onWriteFlush]();
+    this[kOnWriteFlush]!();
     callback?.();
   });
 } as any;


### PR DESCRIPTION
This PR adds a CSP nonce if given in `$global`. fixes: https://github.com/marko-js/express/issues/8

<!--- Provide a general summary of your changes in the Title above -->

## Description

The midstream redirect script should include a CSP nonce if one exists in `$global`

<!--- Describe your changes in detail.  Include the package name if applicable. -->

Since we don't have a handle to `$global` in the redirect function, I can't really think of a better way to add the nonce in without either 

- changing the signature of `res.redirect` (not ideal)
- adding a new variable to `req` or `res` which might break others

## Motivation and Context

We need a CSP Nonce for our security settings

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->

cc @DylanPiercey 

-----

I signed the CLA but still showing an error